### PR TITLE
fixes export_sequences_to_file function to add annotation label

### DIFF
--- a/basicsynbio/main.py
+++ b/basicsynbio/main.py
@@ -20,7 +20,8 @@ DEFAULT_ANNOTATIONS = {
     "date": DATE.strftime("%d-") + DATE.strftime("%b").upper() + DATE.strftime("-%Y"),
     "accessions": [],
     "sequence_version": 1,
-    "topology": "circular"
+    "topology": "circular",
+    "molecule_type": "DNA"
 }
 IP_STR = "TCTGGTGGGTCTCTGTCC"
 IS_STR = "GGCTCGGGAGACCTATCG"


### PR DESCRIPTION
## fixes issue #35 

suggestion fix which allows pytest to run successfully

add another argument to `export_sequences_to_file` called molecule_type which has a default value of "DNA" however, if specified by user during function call it can be different

just before point of writing execution call it adds

```python
basic_object.annotations["molecule_type"] = molecule_type
```

## Notes

If the molecule type will alway be DNA we can remove it as a default function argument and replace code above to the code below

```python
basic_object.annotations["molecule_type"] = "DNA"
```
directly instead.

If not, I will need to update the docs to add another argument, let me know if this seems like a good solution 🙂

