### PR TITLE
Predict clip reaction product

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,6 +60,7 @@ ptyprocess==0.6.0
 py==1.9.0
 pycodestyle==2.6.0
 pycparser==2.20
+pydna==3.1.3
 Pygments==2.6.1
 pylint==2.5.3
 pyparsing==2.4.7

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setuptools.setup(
     python_requires='>=3.7',
     install_requires=[
         "biopython>=1.78",
+        "pydna",
         "icebreaker",
         "python-Levenshtein",
         "sbol2"

--- a/tests/test_basicsynbio.py
+++ b/tests/test_basicsynbio.py
@@ -447,3 +447,14 @@ def test_import_sbol_part():
     # online converter changes annotations attribute
     bseva18_from_sbol.annotations = bsb.BSEVA_PARTS["18"].annotations
     assert compare_seqrec_instances(bseva18_from_sbol, bsb.BSEVA_PARTS["18"]) == True
+
+def test_predict_clip_reaction_product():
+    first60_flat_seq = 'CTTCGTGGAAACACTATTATCTGGTGGGTCTCTGTCCACTAGTCTTGGACTCCTGTTGAT'
+    last60_flat_seq = 'TTATTTGATGCCTTTAATTAAGGCTCGGGAGACCTATCGGTAATAACAGTCCAATCTGGT'
+    prefix = bsb.BIOLEGIO_LINKERS["LMP"]
+    part = bsb.BSEVA_PARTS["18"]
+    suffix = bsb.BIOLEGIO_LINKERS["LMS"]
+    testClip = bsb.main.ClipReaction(prefix,part,suffix)
+    seq = str(testClip.predict_clip_reaction_sequence())
+    assert seq[:60] == first60_flat_seq
+    assert seq[-60:] == last60_flat_seq


### PR DESCRIPTION
## Adresses Issue #31

## Use of Pydna in Function

Researching Pydna (https://pydna.readthedocs.io/)  I found the useful module:
pydna.dseq.Dseq

which contains the function .cut(BsaI) which is useful for predicting clip reaction products.

I created a function within the class `ClipReaction` which uses all three variables created on init

```python
def predict_clip_reaction_sequence(self):
```

Within the function I loaded sequence data into the pydna Dseq object

```python
partDseq = Dseq(str(part.seq))
```

The cut function returns a list of fragments remaining after BsaI restiction/digestion has occured, for the part object, we want the central fragment which is in the [1] index from [0,1,2]

```python
cutPart = partDseq.cut(BsaI)[1]
```

You can visualise Dseq Object well with the following function
```python
print(repr(cutPart))
```
<img width="231" alt="Screenshot 2020-11-01 at 16 05 48" src="https://user-images.githubusercontent.com/53439684/97808712-5006e780-1c60-11eb-84df-54abb5b2e426.png">
^ my screenshot

The above sticky ends follow the ideal format with the 4bp and 6bp scar shown below
<img width="600" alt="Screenshot 2020-11-01 at 16 36 32" src="https://user-images.githubusercontent.com/53439684/97808755-92c8bf80-1c60-11eb-888e-5565858a2af6.png">
^ https://academic.oup.com/synbio/article/5/1/ysaa010/5869449
^ DNA-BOT: a low-cost, automated DNA assembly platform for synthetic biology

## Linker handling

Linkers were also cut with the same function and the desired fragment was selected

Note:
prefixDseq object needs to be extended, as during cut a fragment is not created unless there is both a watson and crick sequence overlapping and on the prefix the cut goes right to the end of the prefix touching the DNA Part. On crick initially overlap is 0, This problem is solved by adding an extra string character to ensure the cut function works successfully. This does not affect output at all as the final fragment in prefix is discarded

```python
prefixDseq = Dseq(str(self._prefix.seq)+str('G'))
```

Further processing was required for the prefix and suffix to create half linkers, this was done following the below image

<img width="600" alt="Screenshot 2020-11-01 at 12 47 40" src="https://user-images.githubusercontent.com/53439684/97803208-7ddc3400-1c40-11eb-9d05-18d4991a6ce3.png">

^BASIC: A Simple and Accurate Modular DNA Assembly Method

Processing was done to achieve the correct half linker size, this was possible with Pydna as you can handle objects with seperate watson and crick strings which makes handling the overhangs alot easier

The resulting suffix displayed as a Dseq Object
<img width="236" alt="Screenshot 2020-11-01 at 16 05 24" src="https://user-images.githubusercontent.com/53439684/97808854-2f8b5d00-1c61-11eb-8b1b-7ff80d192f8e.png">

The resulting prefix displayed as a Dseq Object
<img width="229" alt="Screenshot 2020-11-01 at 16 06 13" src="https://user-images.githubusercontent.com/53439684/97808857-3b771f00-1c61-11eb-81f6-aa8bf49c0829.png">

As the sticky ends match you can use simple addition to create final sequence prediction

<img width="272" alt="Screenshot 2020-11-01 at 16 06 31" src="https://user-images.githubusercontent.com/53439684/97808881-619cbf00-1c61-11eb-9b96-5601d1b2b964.png">

# Images above were created with the following files

linkerP = bsb.BIOLEGIO_LINKERS["LMP"]
part = bsb.BSEVA_PARTS["18"]
linkerS = bsb.BIOLEGIO_LINKERS["LMS"]

## Unit Test

A unit test was written with the above files which ensures when flattened the first 60 and last 60 base pairs match the desired output, I chose this number as it encompasses both half linker/part connections

## Docs
I added a doc string in the same format as the others specifying inputs and outputs

I hope I didn't misunderstand something about these clip reactions, it's not my forte, let me know what you think 😁
