### PR TITLE
removes all warnings from pytest

### DIFF
--- a/sequences/genbank_files/misc_BASIC/five_part_assembly.gb
+++ b/sequences/genbank_files/misc_BASIC/five_part_assembly.gb
@@ -158,3 +158,4 @@ ORIGIN
      5641 gtcaagacca cctacaaggc caagaagccc gtgcagctgc ccggcgccta caacgtcaac
      5701 atcaagttgg acatcacctc ccacaacgag gactacacca tcgtggaaca gtacgaacgc
      5761 gccgagggcc gccactccac cggcggcatg gacgagctgt acaagtaa
+//

--- a/tests/test_basicsynbio.py
+++ b/tests/test_basicsynbio.py
@@ -81,7 +81,7 @@ def five_part_assembly(five_part_assembly_parts, five_part_assembly_linkers):
         parts_linkers += list(part_linker)
     print([part_linker.id for part_linker in parts_linkers])
     print([type(part_linker) for part_linker in parts_linkers])
-    return bsb.BasicAssembly("five_part_assembly", *parts_linkers)
+    return bsb.BasicAssembly("5_part", *parts_linkers)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Removes previous 3 warnings when you run pytest

Old output
```bash
================================================= warnings summary ==================================================
tests/test_basicsynbio.py::testreturn_seqrec
tests/test_basicsynbio.py::test_return_part
  /Users/Benedict/Documents/LondonBioFoundry/test6venv/lib/python3.8/site-packages/Bio/GenBank/Scanner.py:1219: BiopythonParserWarning: Premature end of file in sequence data
    warnings.warn(

tests/test_basicsynbio.py::test_export_to_file
  /Users/Benedict/Documents/LondonBioFoundry/test6venv/lib/python3.8/site-packages/Bio/SeqIO/InsdcIO.py:721: BiopythonWarning: Increasing length of locus line to allow long name. This will result in fields that are not in usual positions.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
===================================== 27 passed, 5 skipped, 3 warnings in 3.19s =====================================
```

The first two warnings were caused by not having the '//' character at the end of a genbank file

The last warning was caused by the locus of the test_export.gb file which was created at line 248 being too long, documentation says it should by less than 16 characters, by reducing the length of the locus string we can supress the error

Now no warnings are mentioned during pytest with these changes

```bash
=========================================== 27 passed, 5 skipped in 2.86s ===========================================
```