### PR TITLE
adds package data type to pypi #28

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(exclude=('tests',)),
-    package_data={
-        "": ["*.gb"],
-    },
+    include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
It is true that genbank files previously were not migrated to pypi.
Once I uploaded to pypi and attempted to install I recieved the following error

```bash
File "<frozen importlib._bootstrap_external>", line 988, in open_resource
FileNotFoundError: [Errno 2] No such file or directory: '/Users/Benedict/Documents/LondonBioFoundry/testpypi2env/lib/python3.8/site-packages/basicsynbio/parts_linkers/BASIC_promoter_collection.gb'
```

To solve this we needed to specify the type of the data files stored within the package to ensure they are migrated, this is probably because .gb is a unsual file type for most packages

now with this pull request .gb files can be successfully migrated

after creating a virtual env

```bash
$ pip install --extra-index-url https://test.pypi.org/simple/ basicsyntesttest==0.1.3
$ python
```

```python
>>> import basicsynbio as bsb
RDFLib Version: 5.0.0
>>> basic_seva18 = bsb.BSEVA_PARTS["18"]
>>> print(bsb.BSEVA_PARTS)
12 id: BASIC_SEVA_12
12 name: BASIC_SEVA_12
....
```
let me know what you think @hainesm6 

### Comments

This might be a good time to future proof if you envision using other types of data files in the future to we can add them in this array e.g. .rdf


