### PR TITLE
CSV#54

### DIFF
--- a/basicsynbio/cam.py
+++ b/basicsynbio/cam.py
@@ -179,13 +179,17 @@ class BasicBuild:
                     }
                 )
         with open(Path.cwd() / "assemblies.csv", "w", newline="") as f:
-            fieldnames = ["Assembly index", "Assembly ID", "Clip indexes"]
+            fieldnames = [
+                "Assembly Index",
+                "Assembly ID",
+                "Clip indexes"
+            ]
             thewriter = csv.DictWriter(f, fieldnames=fieldnames)
             thewriter.writeheader()
             for index, assembly in enumerate(self.basic_assemblies):
                 thewriter.writerow(
                     {
-                        "Assembly index": index + 1,
+                        "Assembly Index": index + 1,
                         "Assembly ID": assembly.id,
                         "Clip indexes": [
                             self.unique_clips.index(clip_reaction) + 1


### PR DESCRIPTION
#54 

Hi @hainesm6 
This pull request fixes the capital letters mentioned in the issue #54 

Im not 100% sure what you meant be add `Assembly Name` column to the `assemblies.csv`

In my understanding there wasnt a name, just an id passed in as the first argument to the basic assembly constuctor for example here `promter.id`

```python
build = bsb.BasicBuild(*(bsb.BasicAssembly(
            promoter.id,
            bsb.BASIC_SEVA_PARTS['v0.1']["27"],
            bsb.BASIC_BIOLEGIO_LINKERS['v0.1']["LMP"],
            promoter,
            bsb.BASIC_BIOLEGIO_LINKERS['v0.1']["UTR1-RBS2"],
            bsb.BASIC_CDS_PARTS['v0.1']["sfGFP"],
            bsb.BASIC_BIOLEGIO_LINKERS['v0.1']["LMS"]
        ) for promoter in bsb.BASIC_PROMOTER_PARTS['v0.1'].values()))
```

Do you want me to add the `_seqrecord_hexdigest` hash of the assembly into the `Assembly ID` column and move the old ID into the `Assembly Name` column?

Thanks for any clarification!