### PR TITLE
150BP#47

### DIFF
--- a/tests/test_basicsynbio.py
+++ b/tests/test_basicsynbio.py
@@ -594,23 +594,25 @@ def test_decoded_build(promoter_assemblies_build, promoter_assemblies_json):
         == True
     )
 
+
 def test_error_raise_basic_slice_less_90():
     from Bio.Seq import Seq
-    mypart = bsb.BasicPart(
-        Seq("TCTGGTGGGTCTCTGTCCAAGGCTCGGGAGACCTATCG"),
-        'test'
-    )
+
     with pytest.raises(ValueError):
-        mypart.basic_slice()
+        mypart = bsb.BasicPart(Seq("TCTGGTGGGTCTCTGTCCAAGGCTCGGGAGACCTATCG"), "test")
+
 
 def test_warning_raise_basic_slice_90_150():
     from Bio.Seq import Seq
-    mypart = bsb.BasicPart(
-        Seq("TCTGGTGGGTCTCTGTCCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGGCTCGGGAGACCTATCG"),
-        'test'
-    )
+
     with pytest.warns(UserWarning):
-        mypart.basic_slice()
+        mypart = bsb.BasicPart(
+            Seq(
+                "TCTGGTGGGTCTCTGTCCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGGCTCGGGAGACCTATCG"
+            ),
+            "test",
+        )
+
 
 @pytest.mark.slow
 def test_import_sbol_part():


### PR DESCRIPTION
addresses issue #47 

when basic_slice is called when the sequence is less than 90 base pairs:
```python
mypart1 = bsb.BasicPart(Seq("TCTGGTGGGTCTCTGTCCAAGGCTCGGGAGACCTATCG"),'test')
mypart1.basic_slice()

>>>
ValueError: Basic Slice of part <unknown name> is 38 base pairs long, this is less than 90 base pairs which may cause errors during assembly.
```

when basic_slice is called when the sequence is less between 90 and 150 base pairs, the user is displayed this warning but doesnt interupt the code:
```python
mypart2 = bsb.BasicPart(
        Seq("TCTGGTGGGTCTCTGTCCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGGCTCGGGAGACCTATCG"),
        'test'
    )
mypart2.basic_slice()

>>>
UserWarning: Basic Slice of part <unknown name> is 97 base pairs long, this is between 90 and 150 base pairs which may cause inconsistencies during assembly.
```

This pull request also creates 2 tests to test this functionallity with pytest