### PR TITLE
changes 'temp_id' to name of linker and adds a test with black format

### DIFF
--- a/basicsynbio/parts_linkers/basic_linkers.py
+++ b/basicsynbio/parts_linkers/basic_linkers.py
@@ -99,7 +99,7 @@ def _make_linker(
         object of type linker_class specified in Args.
     """
     seq = Seq("GG" + str_seq)
-    linker = linker_class(seq, id="temp_id", name=name, description=description)
+    linker = linker_class(seq, id=name, name=name, description=description)
     linker.id = seqrecord_hexdigest(linker)
     return linker
 

--- a/docsource/source/literal_includes/make_literals.py
+++ b/docsource/source/literal_includes/make_literals.py
@@ -41,25 +41,30 @@ def export_json(build):
     with open("build.json", "w") as json_file:
         json.dump(build, json_file, cls=bsb.BuildEncoder, indent=4, ensure_ascii=False)
 
+
 def export_BASIC_BIOLEGIO_LINKERS():
     sys.stdout = open("BASIC_BIOLEGIO_LINKERS.txt", "w")
     print(bsb.BASIC_BIOLEGIO_LINKERS["v0.1"])
     sys.stdout.close()
+
 
 def export_BASIC_CDS_PARTS():
     sys.stdout = open("BASIC_CDS_PARTS.txt", "w")
     print(bsb.BASIC_CDS_PARTS["v0.1"])
     sys.stdout.close()
 
+
 def export_BASIC_PROMOTER_PARTS():
     sys.stdout = open("BASIC_PROMOTER_PARTS.txt", "w")
     print(bsb.BASIC_PROMOTER_PARTS["v0.1"])
     sys.stdout.close()
 
+
 def export_BASIC_SEVA_PARTS():
     sys.stdout = open("BASIC_SEVA_PARTS.txt", "w")
     print(bsb.BASIC_SEVA_PARTS["v0.1"])
     sys.stdout.close()
+
 
 if __name__ == "__main__":
     export_json(build_json())

--- a/setup.py
+++ b/setup.py
@@ -13,24 +13,22 @@ setuptools.setup(
     description="An open-source Python package to facilitate BASIC DNA Assembly workflows",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=setuptools.find_packages(exclude=("tests")),  # package_data not correctly migrated if "where" arg used.
+    packages=setuptools.find_packages(
+        exclude=("tests")
+    ),  # package_data not correctly migrated if "where" arg used.
     include_package_data=True,
     classifiers=[
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
-        "Operating System :: OS Independent",        
+        "Operating System :: OS Independent",
         "Programming Language :: Python :: 3.7",
-        "Topic :: Scientific/Engineering :: Bio-Informatics"
+        "Topic :: Scientific/Engineering :: Bio-Informatics",
     ],
     python_requires=">=3.7",
-    install_requires=[
-        "biopython>=1.78",
-        "python-Levenshtein",
-        "sbol2"
-    ],
+    install_requires=["biopython>=1.78", "python-Levenshtein", "sbol2"],
     project_urls={
         "Documentation": "https://londonbiofoundry.github.io/basicsynbio/index.html",
-        "Source": "https://github.com/LondonBiofoundry/basicsynbio"
-    }
+        "Source": "https://github.com/LondonBiofoundry/basicsynbio",
+    },
 )

--- a/tests/test_basicsynbio.py
+++ b/tests/test_basicsynbio.py
@@ -619,6 +619,11 @@ def test_warning_raise_basic_slice_90_150():
         )
 
 
+def test_basic_linker_label():
+    mylinker = bsb.BASIC_BIOLEGIO_LINKERS["v0.1"]["LMP"]
+    boolea = True == "LMP" in mylinker.features[0].qualifiers["label"]
+
+
 @pytest.mark.slow
 def test_import_sbol_part():
     from basicsynbio.cam import seqrecord_hexdigest

--- a/tests/test_basicsynbio.py
+++ b/tests/test_basicsynbio.py
@@ -621,7 +621,7 @@ def test_warning_raise_basic_slice_90_150():
 
 def test_basic_linker_label():
     mylinker = bsb.BASIC_BIOLEGIO_LINKERS["v0.1"]["LMP"]
-    boolea = True == "LMP" in mylinker.features[0].qualifiers["label"]
+    assert "LMP" in mylinker.features[0].qualifiers["label"]
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## #73 

Changes feature label from 'test_id' to the name of the linker, using the suggested change in the issue.

Adds a pytest to confirm functionality.

```python
def test_basic_linker_label():
    mylinker = bsb.BASIC_BIOLEGIO_LINKERS["v0.1"]["LMP"]
    assert "LMP" in mylinker.features[0].qualifiers["label"]
```