### PR TITLE
Img not included - Needed for PDF

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include ./basicsynbio/parts_linkers/*.gb
-include ./basicsynbio/static/*.png
+include basicsynbio/parts_linkers/*.gb
+include basicsynbio/static/*

--- a/basicsynbio/functions/pdf_instructions.py
+++ b/basicsynbio/functions/pdf_instructions.py
@@ -120,9 +120,8 @@ def pdf_instructions(basic_build: BasicBuild, assemblies_per_clip: int = 28):
     pdf = SimpleDocTemplate(pdf_filename, pagesizes=A4)
 
     elems = []
-    elems.append(
-        Image(resources.files("basicsynbio.static") / "introimg.png", 12 * cm, 4 * cm)
-    )
+    with resources.path("basicsynbio.static", "introimg.png") as image_path:
+        elems.append(Image(image_path, 12 * cm, 4 * cm))
     elems.append(Paragraph("Materials", styles["Heading1"]))
     elems.append(Table(PROCESSED_MATERIALS, colWidths=[10.5 * cm, 5 * cm], style=style))
     elems.append(PageBreak())

--- a/basicsynbio/functions/pdf_instructions.py
+++ b/basicsynbio/functions/pdf_instructions.py
@@ -4,6 +4,7 @@ import os
 import pandas as pd
 from pathlib import Path
 from datetime import datetime
+from importlib import resources
 from reportlab.platypus import (
     SimpleDocTemplate,
     ListFlowable,
@@ -119,7 +120,9 @@ def pdf_instructions(basic_build: BasicBuild, assemblies_per_clip: int = 28):
     pdf = SimpleDocTemplate(pdf_filename, pagesizes=A4)
 
     elems = []
-    elems.append(Image("basicsynbio/static/introimg.png", 12 * cm, 4 * cm))
+    elems.append(
+        Image(resources.files("basicsynbio.static") / "introimg.png", 12 * cm, 4 * cm)
+    )
     elems.append(Paragraph("Materials", styles["Heading1"]))
     elems.append(Table(PROCESSED_MATERIALS, colWidths=[10.5 * cm, 5 * cm], style=style))
     elems.append(PageBreak())

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,7 @@ setuptools.setup(
     description="An open-source Python package to facilitate BASIC DNA Assembly workflows",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=setuptools.find_packages(
-        exclude=("tests")
-    ),
+    packages=setuptools.find_packages(exclude=("tests")),
     include_package_data=True,
     classifiers=[
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
Previously export_pdf function did not work as `introimg.png` was not included within the package, when it was it was not found we needed to use `importlib` to specify module like in `basic_parts.py`

Now export_pdf works when the package is downloaded through pypi  and is tested at:

https://test.pypi.org/project/basicsynbiotesting/0.8.0/