### PR TITLE
implements new echo instruction pipeline

### DIFF
--- a/basicsynbio/cam/csv_export.py
+++ b/basicsynbio/cam/csv_export.py
@@ -10,8 +10,8 @@ import csv
 def export_csvs(
     basic_build: BasicBuild,
     path: str = None,
-    clip_plate_mapping: dict = None,
-    assembly_plate_mapping: dict = None,
+    clip_plate_mapping: dict[str, list[str]] = None,
+    assembly_plate_mapping: dict[str, str] = None,
 ):
     """Writes information about each clip_data and assembly to
     two dependent CSV files in the same folder the command
@@ -20,12 +20,12 @@ def export_csvs(
     Args:
         path (optional): path to zipped folder of csv files. If none defaults to
             working directory with a time stamped name, output csvs is created.
-        clip_plate_mapping (optional): A dictionary with a keys containing clip
+        clip_plate_mapping (optional): A dictionary with keys containing clip
             indicies and values containing lists of well locations's where the
             clips are stored.
-        assembly_plate_mapping (optional): A dictionary with a keys containing
-            assembly indicies and values containing lists of well locations's
-            where the assembly is stored.
+        assembly_plate_mapping (optional): A dictionary with keys containing
+            assembly indicies and values containing the assemblies location plate
+            followed by a dash then the well locations for example {1:'0-A1',...}
 
 
     Returns:

--- a/basicsynbio/cam/csv_export.py
+++ b/basicsynbio/cam/csv_export.py
@@ -7,7 +7,12 @@ from datetime import datetime
 import csv
 
 
-def export_csvs(basic_build: BasicBuild, path: str = None):
+def export_csvs(
+    basic_build: BasicBuild,
+    path: str = None,
+    clip_plate_mapping: dict = None,
+    assembly_plate_mapping: dict = None,
+):
     """Writes information about each clip_data and assembly to
     two dependent CSV files in the same folder the command
     is executed.
@@ -15,6 +20,13 @@ def export_csvs(basic_build: BasicBuild, path: str = None):
     Args:
         path (optional): path to zipped folder of csv files. If none defaults to
             working directory with a time stamped name, output csvs is created.
+        clip_plate_mapping (optional): A dictionary with a keys containing clip
+            indicies and values containing lists of well locations's where the
+            clips are stored.
+        assembly_plate_mapping (optional): A dictionary with a keys containing
+            assembly indicies and values containing lists of well locations's
+            where the assembly is stored.
+
 
     Returns:
         str: filepath of created zip containing the CSV files
@@ -35,6 +47,7 @@ def export_csvs(basic_build: BasicBuild, path: str = None):
             "Suffix ID",
             "Total assemblies",
             "Assembly indexes",
+            "Clip plate mapping",
         ]
         thewriter = csv.DictWriter(f, fieldnames=fieldnames)
         thewriter.writeheader()
@@ -55,10 +68,18 @@ def export_csvs(basic_build: BasicBuild, path: str = None):
                         basic_build.basic_assemblies.index(assembly) + 1
                         for assembly in clip_data[1]
                     ],
+                    "Clip plate mapping": clip_plate_mapping[str(index + 1)]
+                    if clip_plate_mapping
+                    else "N/A",
                 }
             )
     with open(Path.cwd() / "assemblies.csv", "w", newline="") as f:
-        fieldnames = ["Assembly Index", "Assembly ID", "Clip indexes"]
+        fieldnames = [
+            "Assembly Index",
+            "Assembly ID",
+            "Clip indexes",
+            "Assembly plate mapping",
+        ]
         thewriter = csv.DictWriter(f, fieldnames=fieldnames)
         thewriter.writeheader()
         for index, assembly in enumerate(basic_build.basic_assemblies):
@@ -70,6 +91,9 @@ def export_csvs(basic_build: BasicBuild, path: str = None):
                         basic_build.unique_clips.index(clip_reaction) + 1
                         for clip_reaction in assembly._clip_reactions
                     ],
+                    "Assembly plate mapping": assembly_plate_mapping[str(index + 1)]
+                    if assembly_plate_mapping
+                    else "N/A",
                 }
             )
     with zipfile.ZipFile(zip_path, "w") as my_zip:

--- a/basicsynbio/cam/echo_instructions.py
+++ b/basicsynbio/cam/echo_instructions.py
@@ -37,7 +37,7 @@ def export_echo_assembly(
         buffer_well (optional): location in 6 well plate of assembly buffer.
         water_well (optional): location in 6 well plate of dH20.
         alternate_well (optional): specifies whether alternating wells are to be used in the input 384 well plate.
-        assemblies_per_clip (optional): amount of clips to be used in each assembly.
+        assemblies_per_clip (optional): number of assemblies each purified clip reaction can support.
         clips_plate_size (optional): specifies the size of the clips plate. Defaults to 384
         assemblies_plate_size (optional): specifiesthe size of the assemblies plates. Defaults to 96
 

--- a/basicsynbio/cam/echo_instructions.py
+++ b/basicsynbio/cam/echo_instructions.py
@@ -37,9 +37,7 @@ def export_echo_assembly(
         buffer_well (optional): location in 6 well plate of assembly buffer.
         water_well (optional): location in 6 well plate of dH20.
         alternate_well (optional): specifies whether alternating wells are to be used in the input 384 well plate.
-        assemblies_per_clip (optional): specifies the number of clip reactions (to create assemblies) one filled
-            well of clips can complete. for example if assemblies_per_clip is set to 20 and the clip is needed for
-            25 clip reaction two wells within the source plate would need to be filled by the same clip
+        assemblies_per_clip (optional): amount of clips to be used in each assembly.
         clips_plate_size (optional): specifies the size of the clips plate. Defaults to 384
         assemblies_plate_size (optional): specifiesthe size of the assemblies plates. Defaults to 96
 

--- a/basicsynbio/cam/pdf_instructions.py
+++ b/basicsynbio/cam/pdf_instructions.py
@@ -46,7 +46,7 @@ def pdf_instructions(
         basic_build: BasicBuild object the pdf lab instructions are written for.
         path (optional): path to zipped folder of csv files. If none defaults to
             working directory with a time stamped name, output csvs is created.
-        assemblies_per_clip (optional): amount of clips to be used in each assembly.
+        assemblies_per_clip (optional): number of assemblies each purified clip reaction can support.
 
     Returns:
         str: filepath of created pdf

--- a/tests/test_function_echo.py
+++ b/tests/test_function_echo.py
@@ -43,6 +43,8 @@ def test_echo_instructions_small_build(small_build_example):
     )
     os.remove(Path.cwd() / "ECHO_CSVS" / "echo_clips_1.csv")
     os.remove(Path.cwd() / "ECHO_CSVS" / "echo_water_buffer_1.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "clips.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "assemblies.csv")
     os.rmdir(Path.cwd() / "ECHO_CSVS")
     expected_clips = [
         ["A1", "A1", 500],
@@ -80,6 +82,8 @@ def test_echo_instructions_small_build_useAllWell_False(small_build_example):
     )
     os.remove(Path.cwd() / "ECHO_CSVS" / "echo_clips_1.csv")
     os.remove(Path.cwd() / "ECHO_CSVS" / "echo_water_buffer_1.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "clips.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "assemblies.csv")
     os.rmdir(Path.cwd() / "ECHO_CSVS")
     expected_clips = [
         ["A1", "A1", 500],
@@ -142,6 +146,8 @@ def test_multiple_files_made_more_than_96_assemblies(promoter_assemblies_build):
     os.remove(Path.cwd() / "ECHO_CSVS" / "echo_water_buffer_1.csv")
     os.remove(Path.cwd() / "ECHO_CSVS" / "echo_clips_2.csv")
     os.remove(Path.cwd() / "ECHO_CSVS" / "echo_water_buffer_2.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "clips.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "assemblies.csv")
     os.rmdir(Path.cwd() / "ECHO_CSVS")
     expected_water_buffer_2 = [
         ["A1", "A1", 500],
@@ -332,6 +338,64 @@ def test_multiple_files_made_more_than_96_assemblies(promoter_assemblies_build):
         ["E12", "B1", 3000],
     ]
     assert expected_water_buffer_2 == echo_water_buffer_2.to_numpy().tolist()
+
+
+def test_multiple_files_made_more_than_96_assemblies_clips_assignment(
+    promoter_assemblies_build,
+):
+    import zipfile
+    import os
+    import pandas as pd
+    import numpy as np
+    from pathlib import Path
+
+    echozippath = bsb.export_echo_assembly(promoter_assemblies_build)
+    with zipfile.ZipFile(echozippath, "r") as zip_ref:
+        try:
+            zip_ref.extractall("ECHO_CSVS")
+        finally:
+            zip_ref.close()
+            os.remove(echozippath)
+    echo_clips_csv = pd.read_csv(Path.cwd() / "ECHO_CSVS" / "clips.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "echo_clips_1.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "echo_water_buffer_1.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "echo_clips_2.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "echo_water_buffer_2.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "clips.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "assemblies.csv")
+    os.rmdir(Path.cwd() / "ECHO_CSVS")
+    echo_clips_first_clip_wells = "['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1']"
+    assert echo_clips_first_clip_wells == echo_clips_csv.to_numpy().tolist()[0][-1]
+
+
+def test_multiple_files_made_more_than_96_assemblies_clips_assignment_with_alternate_wells(
+    promoter_assemblies_build,
+):
+    import zipfile
+    import os
+    import pandas as pd
+    import numpy as np
+    from pathlib import Path
+
+    echozippath = bsb.export_echo_assembly(
+        promoter_assemblies_build, alternate_well=True, clips_plate_size=1536
+    )
+    with zipfile.ZipFile(echozippath, "r") as zip_ref:
+        try:
+            zip_ref.extractall("ECHO_CSVS")
+        finally:
+            zip_ref.close()
+            os.remove(echozippath)
+    echo_clips_csv = pd.read_csv(Path.cwd() / "ECHO_CSVS" / "clips.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "echo_clips_1.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "echo_water_buffer_1.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "echo_clips_2.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "echo_water_buffer_2.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "clips.csv")
+    os.remove(Path.cwd() / "ECHO_CSVS" / "assemblies.csv")
+    os.rmdir(Path.cwd() / "ECHO_CSVS")
+    echo_clips_first_clip_wells = "['A1', 'C1', 'E1', 'G1', 'I1', 'K1', 'M1']"
+    assert echo_clips_first_clip_wells == echo_clips_csv.to_numpy().tolist()[0][-1]
 
 
 def test_echo_instructions_too_many_clips(promoter_assemblies_build_more_than_384):


### PR DESCRIPTION
Addresses #134 

```python
import basicsynbio as bsb
import zipfile
import os
import pandas as pd
from pathlib import Path

utr_linkers = ["UTR1-RBS1"]
promoter_assemblies = []
for utr_linker in utr_linkers:
    promoter_assemblies += [
        bsb.BasicAssembly(
            f"promoter_construct_{ind}_{utr_linker}",
            bsb.BASIC_SEVA_PARTS["v0.1"]["26"],
            bsb.BASIC_BIOLEGIO_LINKERS["v0.1"]["LMP"],
            promoter,
            bsb.BASIC_BIOLEGIO_LINKERS["v0.1"][utr_linker],
            bsb.BASIC_CDS_PARTS["v0.1"]["sfGFP"],
            bsb.BASIC_BIOLEGIO_LINKERS["v0.1"]["LMS"],
        )
        for ind, promoter in enumerate(bsb.BASIC_PROMOTER_PARTS["v0.1"].values())
    ]
my_build = bsb.BasicBuild(*promoter_assemblies)
echozippath = bsb.export_echo_assembly(
    my_build, alternate_well=True, clips_plate_size=1536
)
```
An example of the new zip file that is created when the above code is ran

[Echo_Instructions_17-06-2021_16.54.28.zip](https://github.com/LondonBiofoundry/basicsynbio/files/6671574/Echo_Instructions_17-06-2021_16.54.28.zip)

the following three arguments are added to echo_instructions

-     assemblies_per_clip: int = 28,
-     clips_plate_size: Literal[6, 24, 96, 384, 1536] = 384,
-     assemblies_plate_size: Literal[6, 24, 96, 384, 1536] = 96,

the following arguments are added to csv_export

-     clip_plate_mapping: dict = None,
-     assembly_plate_mapping: dict = None,

The original echo_instruction unit tests have not been changed and still pass which is ideal, and new unit tests are added to check the new columns of the csv with and without alternate_wells
